### PR TITLE
Expanded underrepresented group examples for scholarship

### DIFF
--- a/templates/scholarship.html
+++ b/templates/scholarship.html
@@ -13,8 +13,25 @@
         Our scholarship fund will support about twenty people to attend Django: Under The Hood. Scholarships are fully sponsored (i.e. free) tickets that are awarded after an application process. Travel expenses and accommodation, if required, will also be awarded.
     </p>
     <p>
-        Anyone from an underrepresented group in tech is invited to apply for this scholarship. This includes, but is not limited to: women, people of colour, LGBTQIA+ people, people with disabilities, and people facing economic or social hardships.
+        Anyone from an underrepresented group in tech is invited to apply for this scholarship. This includes, but is not limited to:
     </p>
+    <ul>
+        <li>women and other gender minorities of all expressions and identities; e.g. trans, agender and non-binary</li>
+        <li>people of color, including Indigenous/Native people</li>
+        <li>sexuality minorities, including asexual people</li>
+        <li>people with disabilities, both visible and invisible</li>
+        <li>neurodiverse people</li>
+        <li>people with chronic illnesses or diseases</li>
+        <li>religious and ethnic minorities</li>
+        <li>people who don't speak English as a first language</li>
+        <li>undocumented people (US), naturalized people, and refugees</li>
+        <li>age minorities (under 21, over 50)</li>
+        <li>working class people and people experiencing poverty</li>
+        <li>homeless and home/food insecure people</li>
+        <li>caregivers of children or other dependents</li>
+        <li>people who have experienced trauma and its aftermath (PTSD, anxiety, etc)</li>
+        <li>people living with or recovering from substance abuse</li>
+    </ul>
     <p>
         The application process is simple: Tell us about what you do with Python or Django, and why you want to attend Django: Under The Hood.
     </p>
@@ -30,7 +47,7 @@
         <li>1st of July: Award recipients will be notified by email of their acceptance.</li>
     </ul>
 
-    <p>Thank you <a href="http://2015.jsconf.eu/">JSConf EU</a> for providing a great example of the process we're adopting.</p>
+    <p>Thank you <a href="http://2015.jsconf.eu/">JSConf EU</a> for providing a great example of the process we're adopting, and to <a href="http://www.alterconf.com/">AlterConf</a> for further inspiration.</a>.</p>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
This expands the list of examples of underrepresented groups to include many more examples. This list is mostly adopted from AlterConf with a few tweaks. I'm not fixated on every word of this, we may need to make more tweaks.

The idea behind this is that I think there are people from underrepresented groups, especially those not visible or not often mentioned, that would not feel welcome in the scholarship program because they are not included in our list. We do already have a "not limited to" clause, but listing groups explicitly is a much stronger message that those people are welcome to apply.